### PR TITLE
Docker compatibility with arch-based distros

### DIFF
--- a/cpp-template/.devcontainer/Dockerfile
+++ b/cpp-template/.devcontainer/Dockerfile
@@ -32,6 +32,8 @@ ENV ZEPHYR_BASE="/home/vscode/zephyrproject/zephyr"
 # Grant user access to plugdev
 USER vscode
 RUN sudo usermod -aG plugdev $(whoami)
+# Grant user access to uucp group - to be compatible with arch-based distros
+RUN sudo usermod -aG uucp $(whoami)
 
 # Get Zephyr and install Python dependencies
 RUN pip3 install --user -U west \

--- a/custom-board/.devcontainer/Dockerfile
+++ b/custom-board/.devcontainer/Dockerfile
@@ -32,6 +32,8 @@ ENV ZEPHYR_BASE="/home/vscode/zephyrproject/zephyr"
 # Grant user access to plugdev
 USER vscode
 RUN sudo usermod -aG plugdev $(whoami)
+# Grant user access to uucp group - to be compatible with arch-based distros
+RUN sudo usermod -aG uucp $(whoami)
 
 # Get Zephyr and install Python dependencies
 RUN pip3 install --user -U west \

--- a/hello-world/.devcontainer/Dockerfile
+++ b/hello-world/.devcontainer/Dockerfile
@@ -32,6 +32,8 @@ ENV ZEPHYR_BASE="/home/vscode/zephyrproject/zephyr"
 # Grant user access to plugdev
 USER vscode
 RUN sudo usermod -aG plugdev $(whoami)
+# Grant user access to uucp group - to be compatible with arch-based distros
+RUN sudo usermod -aG uucp $(whoami)
 
 # Get Zephyr and install Python dependencies
 RUN pip3 install --user -U west \


### PR DESCRIPTION
To be compatible with arch-based distros (verified on Manjaro). As a default, all of `/dev/tty*` are added to `uucp` group (more info on Arch wiki: https://wiki.archlinux.org/title/users_and_groups#User_groups). Without that `west flash` returns `LIBUSB_ERROR_NO_DEVICE`.

Thanks for that template!